### PR TITLE
Add encoder error check to IK

### DIFF
--- a/arm_main/include/ArmJoint.h
+++ b/arm_main/include/ArmJoint.h
@@ -12,10 +12,10 @@
 const float PRECISION = 1;
 
 const float MAX_SPEED = 500;
-const float MIN_SPEED = 50;
+const float MIN_SPEED = 100;
 
 const float dt = 50;  // ms
-const float kP = 1.0;
+const float kP = 10.0;
 const float kI = 0.0;
 const float kD = 0.0;
 

--- a/arm_main/include/ArmJoint.h
+++ b/arm_main/include/ArmJoint.h
@@ -11,7 +11,7 @@
 
 const float PRECISION = 1;
 
-const float MAX_SPEED = 1000;
+const float MAX_SPEED = 500;
 const float MIN_SPEED = 50;
 
 const float dt = 50;  // ms
@@ -62,5 +62,15 @@ class ArmJoint {
         } else if (targetAngle > maxAngle) {
             targetAngle = maxAngle;
         }
+    }
+
+    inline bool checkDuty(float duty) {
+        if (inverted)
+            duty = -duty;
+        if ((lastEffectiveAngle > maxAngle && duty < 0)
+            || (lastEffectiveAngle < minAngle && duty > 0)) {
+            return false;
+        }
+        return true;
     }
 };

--- a/arm_main/src/AstraArm.cpp
+++ b/arm_main/src/AstraArm.cpp
@@ -42,8 +42,7 @@ void AstraArm::updateIKMotion() {
         float newDutyCycles[4] = {lastDutyCycles[0], lastDutyCycles[1], lastDutyCycles[2], lastDutyCycles[3]};
 
         for (int i = 0; i < 4; i++) {
-            if ((joints[i]->lastEffectiveAngle > joints[i]->maxAngle && lastDutyCycles[i] < 0)
-             || (joints[i]->lastEffectiveAngle < joints[i]->minAngle && lastDutyCycles[i] > 0)) {
+            if (!joints[i]->checkDuty(lastDutyCycles[i])) {
                 wasLimitViolation = true;
                 newDutyCycles[i] = 0;
             }
@@ -64,15 +63,12 @@ void AstraArm::updateIKMotion() {
 void AstraArm::runDuty(float dutyCycles[4]) {
     isIKMode = false;
 
-    float newDutyCycles[4] = {0};
+    float newDutyCycles[4] = {dutyCycles[0], dutyCycles[1], dutyCycles[2], dutyCycles[3]};
 
     // Check angle limits and Adjust duty cycles to account for gear ratio
     for (int i = 0; i < 4; i++) {
-        if ((joints[i]->lastEffectiveAngle > joints[i]->maxAngle && dutyCycles[i] < 0)
-         || (joints[i]->lastEffectiveAngle < joints[i]->minAngle && dutyCycles[i] > 0)) {
+        if (!joints[i]->checkDuty(dutyCycles[i])) {
             newDutyCycles[i] = 0;
-        } else {
-            newDutyCycles[i] = dutyCycles[i];
         }
 
         // Axis 1 has the highest gear ratio, scale by ratio between this axis's gear ratio

--- a/arm_main/src/main.cpp
+++ b/arm_main/src/main.cpp
@@ -230,7 +230,7 @@ void loop() {
         float vBatt = convertADC(analogRead(PIN_VDIV_BATT), 10, 2.21);
         float v12 = convertADC(analogRead(PIN_VDIV_12V), 10, 3.32);
         float v5 = convertADC(analogRead(PIN_VDIV_5V), 10, 10);
-        float v33 = convertADC(analogRead(PIN_VDIV_3V3), 10, 1.1);
+        float v33 = convertADC(analogRead(PIN_VDIV_3V3), 10, 10);
 
         vicCAN.send(CMD_POWER_VOLTAGE, vBatt * 100, v12 * 100, v5 * 100, v33 * 100);
     }


### PR DESCRIPTION
IK will no longer move a joint if there is an error getting the angle from its magnetic encoder. This is not in response to anything at all.